### PR TITLE
M3/multitraits

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,3 @@ b2 = f(b)
   with the multiple inheritance used in Traits.jl?
   *Now with multi-traits functions this may not be necessary anymore:
   the intersection of two traits can divide the types into four groups.*
-- could there be Vararg traits?  Generally yes as there are vararg
-  methods.  However, in the current system it is not that easy as
-  there are no Vararg types.  Maybe `Tr{Tuple{X,Y,...}}` could work.

--- a/README.md
+++ b/README.md
@@ -178,3 +178,7 @@ b2 = f(b)
   with the multiple inheritance used in Traits.jl?
   *Now with multi-traits functions this may not be necessary anymore:
   the intersection of two traits can divide the types into four groups.*
+- For trait Collections, Intersections, and TUnion, should a Union be
+  used for the underlying storage as that sorts and purges its inputs?
+  This would rely on un-supported Union behaviour, however it might be
+  quite nice.

--- a/src/SimpleTraits.jl
+++ b/src/SimpleTraits.jl
@@ -312,12 +312,34 @@ isnegated(t::Expr) = t.head==:call  && t.args[1]==:!
 # [:(x::X)] -> [:x]
 strip_tpara(args::Vector) = Any[strip_tpara(a) for a in args]
 strip_tpara(a::Symbol) = a
-strip_tpara(a::Expr) = a.args[1]
+function strip_tpara(a::Expr)
+    if a.head==:(::)
+        return a.args[1]
+    elseif a.head==:...
+        return Expr(:..., strip_tpara(a.args[1]))
+    else
+        error("Cannot parse argument: $a")
+    end
+end
 
 # insert dummy: ::X -> gensym()::X
+# also takes care of ...
 insertdummy(args::Vector) = Any[insertdummy(a) for a in args]
 insertdummy(a::Symbol) = a
-insertdummy(a::Expr) = (a.head==:(::) && length(a.args)==1) ? Expr(:(::), gensym(), a.args[1]) : a
+function insertdummy(a::Expr)
+    if a.head==:...
+        dotdot = true
+        a = a.args[1]
+    else
+        dotdot = false
+    end
+    if !isa(a, Symbol) && a.head==:(::) && length(a.args)==1
+        out = Expr(:(::), gensym(), a.args[1])
+    else
+        out = a
+    end
+    dotdot ? Expr(:..., out) : out
+end
 
 # generates: X1, X2,... or x1, x2.... (just symbols not actual TypeVar)
 type GenerateTypeVars{CASE}

--- a/src/SimpleTraits.jl
+++ b/src/SimpleTraits.jl
@@ -310,6 +310,7 @@ end
 isnegated(t::Expr) = t.head==:call  && t.args[1]==:!
 
 # [:(x::X)] -> [:x]
+# also takes care of :...
 strip_tpara(args::Vector) = Any[strip_tpara(a) for a in args]
 strip_tpara(a::Symbol) = a
 function strip_tpara(a::Expr)
@@ -323,22 +324,17 @@ function strip_tpara(a::Expr)
 end
 
 # insert dummy: ::X -> gensym()::X
-# also takes care of ...
+# also takes care of :...
 insertdummy(args::Vector) = Any[insertdummy(a) for a in args]
 insertdummy(a::Symbol) = a
 function insertdummy(a::Expr)
-    if a.head==:...
-        dotdot = true
-        a = a.args[1]
+    if a.head==:(::) && length(a.args)==1
+        return Expr(:(::), gensym(), a.args[1])
+    elseif a.head==:...
+        return Expr(:..., insertdummy(a.args[1]))
     else
-        dotdot = false
+        return a
     end
-    if !isa(a, Symbol) && a.head==:(::) && length(a.args)==1
-        out = Expr(:(::), gensym(), a.args[1])
-    else
-        out = a
-    end
-    dotdot ? Expr(:..., out) : out
 end
 
 # generates: X1, X2,... or x1, x2.... (just symbols not actual TypeVar)

--- a/src/base-traits.jl
+++ b/src/base-traits.jl
@@ -1,16 +1,7 @@
 module BaseTraits
 using SimpleTraits
 
-export IsLeafType, IsBits, IsImmutable, IsContiguous, IsFastLinearIndex,
-       IsAnything, IsNothing, IsCallable
-
-"Trait which contains all types"
-@traitdef IsAnything{X}
-SimpleTraits.trait{X}(::Type{IsAnything{X}}) = IsAnything{X}
-
-"Trait which contains no types"
-typealias IsNothing{X} Not{IsAnything{X}}
-
+export IsLeafType, IsBits, IsImmutable, IsContiguous, IsFastLinearIndex, IsCallable
 
 "Trait of all isbits-types"
 @traitdef IsBits{X}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,7 @@ immutable B end
 @traitimpl TT2{B}
 
 # intersections
-@test trait(Intersection{Tuple{TT1{A},TT2{B}}})==Intersection{Tuple{TT1{A}, TT2{B}}}
+@test trait(Intersection{Tuple{TT1{A},TT2{B}}})==    Intersection{Tuple{TT1{A}, TT2{B}}}
 @test trait(Intersection{Tuple{TT1{A},TT2{A}}})==Not{Intersection{Tuple{TT1{A}, TT2{A}}}}
 @test trait(Intersection{Tuple{TT1{B},TT2{B}}})==Not{Intersection{Tuple{TT1{B}, TT2{B}}}}
 @test trait(Intersection{Tuple{TT1{B},TT2{A}}})==Not{Intersection{Tuple{TT1{B}, TT2{A}}}}
@@ -169,6 +169,7 @@ typealias SI4{X,Y} Intersection{Tuple{TT1{X}, TT2{Y}}}  # just an alias for the 
 X,Y = TypeVar(:XX, true), TypeVar(:YY,true)
 @test SI4{X,Y}===Intersection{Tuple{TT1{X}, TT2{Y}}}
 @test trait(SI4{A,B})===SI4{A,B}
+@test trait(SI4{A,A})===SI4{A,A} # <-- some julia-issue here!
 @test trait(SI4{B,B})===Not{SI4{B,B}}
 
 @traitfn f56{X,Y;  SI4{X,Y}}(x::X, y::Y) # note that SI4 is similar to {TT1{X},  TT2{Y}}
@@ -180,11 +181,24 @@ X,Y = TypeVar(:XX, true), TypeVar(:YY,true)
 @test f56(B(),B())==2
 @test f56(B(),A())==2
 
-# Subtraits
-@traitdef ST4{X,Y} <: TT1{X}, TT2{Y}  # just an alias for the Collectionsection
+# Trait inheritance
+@traitdef ST2{X,Y} <: TT1{X}
+@traitimpl ST2{A,B}
+@test istrait(ST2{A,B})
+@traitdef ST4{X,Y} <: TT1{X}, TT2{Y}
 X,Y = TypeVar(:XX, true), TypeVar(:YY,true)
 @test super(ST4{X,Y}).parameters[1]===Intersection{Tuple{TT1{X}, TT2{Y}}}
+@traitimpl ST4{A,B}
+@test istrait(ST4{A,B})
+@test_throws ST.TraitException @traitimpl ST4{Int,B}
+@traitimpl TT1{Int}
+@traitimpl ST4{Int,B}
+@test istrait(ST4{Int,B})
 
+
+######
+# TODO
+######
 
 ## Default arguments
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,10 +82,20 @@ immutable B end
 @test f(5.)==10
 
 # VarArg
-@traitfn g{X; Tr1{X}}(x::X, y...)
-@traitfn g{X; Tr1{X}}(x::X, y...) = y
-@test g(5, 7, 8)==((7,8),)
-# @test g(5.0, 7, 8)==((7,8),) # hangs because of https://github.com/JuliaLang/julia/issues/13183
+@traitfn vara{X; Tr1{X}}(x::X, y...)
+@traitfn vara{X; Tr1{X}}(x::X, y...) = y
+@test vara(5, 7, 8)==(7,8)
+# @test vara(5.0, 7, 8)==((7,8),) # hangs in lowering because of https://github.com/JuliaLang/julia/issues/13183
+@traitfn vara2{X; Tr1{X}}(x::X...)
+@traitfn vara2{X; Tr1{X}}(x::X...) = x
+@test vara2(5, 7, 8)==(5, 7, 8)
+@test_throws MethodError vara2(5, 7, 8.0)
+
+@traitfn vara3{X; Tr1{X}}(::X...)
+@traitfn vara3{X; Tr1{X}}(::X...) = X
+@test vara3(5, 7, 8)==Int
+@test_throws MethodError vara3(5, 7, 8.0)
+
 
 # with macro
 @traitfn @inbounds gg{X; Tr1{X}}(x::X)
@@ -173,6 +183,10 @@ println("-- endof ok warning.")
 # @test f56(B(),B())==2  # this does not work because Not{ST4}!={!TT1{X},  TT2{Y}}
 # @test f56(B(),A())==3
 # --> needs to be implemented with method II in traitdef.  Method III does not work!
+
+## Default arguments
+
+## Keyword
 
 ######
 # Other tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
 using SimpleTraits
 using Base.Test
 
-trait = SimpleTraits.trait
-Inter = SimpleTraits.TraitIntersection
+ST = SimpleTraits
+trait = ST.trait
+Inter = ST.TraitIntersection
 
 immutable A end
 immutable B end
@@ -47,11 +48,18 @@ immutable B end
 @test trait(Tr2{Int, Float32})==Not{Tr2{Int, Float32}}
 
 # trait functions
+@traitfn f{X; Tr1{X}}(x::X)
 @traitfn f{X; Tr1{X}}(x::X) = 1  # def 1
 @traitfn f{X; !Tr1{X}}(x::X) = 2
 @test f(5)==1
-@test f(5.)==2
+@test f(5.)== 2
+# try adding a trait which was not part of original init:
+@traitdef Tr0{X}
+@traitimpl Tr0{A}
+@traitfn f{X; Tr0{X}}(x::X) = 99
+@test f(A())!=99
 
+@traitfn f{X,Y; Tr2{X,Y}}(x::X,y::Y,z)
 @traitfn f{X,Y; Tr2{X,Y}}(x::X,y::Y,z) = 1
 @test f(5,5., "a")==1
 @test_throws MethodError f(5,5, "a")==2
@@ -59,6 +67,7 @@ immutable B end
 @test f(5,5, "a")==2
 
 # This will overwrite the definition def1 above
+@traitfn f{X; !Tr2{X,X}}(x::X)
 @traitfn f{X; !Tr2{X,X}}(x::X) = 10
 @traitfn f{X; Tr2{X,X}}(x::X) = 100
 @test f(5)==10
@@ -67,33 +76,39 @@ immutable B end
 @test f(5.)==10
 @test !(f(5)==100)
 # need to update method cache:
+@traitfn f{X; !Tr2{X,X}}(x::X)
 @traitfn f{X; Tr2{X,X}}(x::X) = 100
 @test f(5)==100
 @test f(5.)==10
 
 # VarArg
+@traitfn g{X; Tr1{X}}(x::X, y...)
 @traitfn g{X; Tr1{X}}(x::X, y...) = y
 @test g(5, 7, 8)==((7,8),)
 # @test g(5.0, 7, 8)==((7,8),) # hangs because of https://github.com/JuliaLang/julia/issues/13183
 
 # with macro
+@traitfn @inbounds gg{X; Tr1{X}}(x::X)
 @traitfn @inbounds gg{X; Tr1{X}}(x::X) = x
 @test gg(5)==5
+@traitfn @generated ggg{X; Tr1{X}}(x::X)
 @traitfn @generated ggg{X; Tr1{X}}(x::X) = X<:AbstractArray ? :(x+1) : :(x)
 @test ggg(5)==5
 @traitimpl Tr1{AbstractArray}
 @test ggg([5])==[6]
 
 # traitfn with Type
+@traitfn ggt{X; Tr1{X}}(::Type{X}, y)
 @traitfn ggt{X; Tr1{X}}(::Type{X}, y) = (X,y)
 @test ggt(Array, 5)==(Array, 5)
 
 # traitfn with ::X
+@traitfn gg27{X; Tr1{X}}(::X)
 @traitfn gg27{X; Tr1{X}}(::X) = X
 @test gg27([1])==Array{Int,1}
 
 
-# Tuple traits
+# # Tuple traits
 # typealias STr3{X,Y} Inter{Tuple{Tr1{X}, Tr2{X,Y}}}
 # @test istrait(STr3{Int,Float64})
 # @traitfn f54{X, Y;  STr3{X,Y}}(x::X, y::Y) = 1
@@ -106,21 +121,10 @@ immutable B end
 # @traitimpl Tr2{A, Float64}
 # @test f54(A(),5.0)==1
 
-# # nested subtraits
-# @traitdef Tr3{X}
-# @traitimpl Tr3{A}
-# typealias STr4{X,Y} Inter{Tuple{STr3{X,Y}, Tr3{X}}}
-# @test istrait(STr4{A, Float64})
-# @test !istrait(STr4{Float64, A})
-# # use traitdef syntax:
-# @traitdef STr44{X,Y} <: STr3{X,Y}, Tr3{X}
-# @test STr44===STr4
-# @test STr44{A,Int}===STr4{A,Int}
-
-## several traits
-@traitdef TT1{X}
+## Trait intersections
+@traitdef  TT1{X}
 @traitimpl TT1{A}
-@traitdef TT2{Y}
+@traitdef  TT2{Y}
 @traitimpl TT2{B}
 # this gives combinations:
 @test trait(Inter{Tuple{TT1{A},TT2{B}}})==Inter{Tuple{    TT1{A} ,     TT2{B} }}
@@ -128,18 +132,47 @@ immutable B end
 @test trait(Inter{Tuple{TT1{B},TT2{B}}})==Inter{Tuple{Not{TT1{B}},     TT2{B} }}
 @test trait(Inter{Tuple{TT1{B},TT2{A}}})==Inter{Tuple{Not{TT1{B}}, Not{TT2{A} }}}
 
+@traitfn f55{X, Y;  TT1{X},  TT2{Y}}(x::X, y::Y)
+@traitfn f55{X, Y;  TT1{X},  TT2{Y}}(x::X, y::Y) = 1
+@traitfn f55{X, Y; !TT1{X},  TT2{Y}}(x::X, y::Y) = 2
+@traitfn f55{X, Y; !TT1{X}, !TT2{Y}}(x::X, y::Y) = 3
 
+@test f55(A(),B())==1
+@test f55(B(),B())==2
+@test f55(B(),A())==3
 
+@traitfn f55{X, Y; !TT2{Y}, TT1{X}}(x::X, y::Y) = 4 # oops traits are in reverse order!
+@test_throws MethodError f55(A(),A())==4
+@traitfn f55{X, Y; TT1{X}, !TT2{Y}}(x::X, y::Y) = 4
+@test f55(A(),A())==4
 
-# @traitfn f55{X, Y;  TT1{X},  TT2{Y}}(x::X, y::Y) = 1
-# @traitfn f55{X, Y; !TT1{X},  TT2{Y}}(x::X, y::Y) = 2
-# @traitfn f55{X, Y; !TT1{X}, !TT2{Y}}(x::X, y::Y) = 3
-# @traitfn f55{X, Y;  TT1{X}, !TT2{Y}}(x::X, y::Y) = 4
+# this fails because the generated-function has already been created above:
+@traitimpl TT2{A}
+@test !(trait(Inter{Tuple{TT1{A},TT2{A}}})==Inter{Tuple{    TT1{A} , TT2{A} }})
+println("-- This warning is ok:")
+ST.@reset_trait_intersections
+println("-- endof ok warning.")
+@test trait(Inter{Tuple{TT1{A},TT2{A}}})==Inter{Tuple{    TT1{A} , TT2{A} }}
 
-# @test f55(A(),B())==1
-# @test f55(B(),B())==2
-# @test f55(B(),A())==3
-# @test f55(A(),A())==4
+@traitfn f55{X, Y;  TT1{X},  TT2{Y}}(x::X, y::Y)
+@test f55(A(),A())==1
+
+# # Subtraits
+@test_throws ST.TraitException @traitdef TT4{X,Y} <: Tr2{X,Y}, Tr1{X} #  are not allowed
+# @traitdef ST4{X,Y} <: TT1{X}, TT2{Y}  # just an alias for the Intersection
+# X,Y = TypeVar(:XX, true), TypeVar(:YY,true)
+# @test ST4{X,Y}===Inter{Tuple{TT1{X}, TT2{Y}}}
+# @test !(ST4{X,Y}===Inter{Tuple{TT1{Y}, TT2{X}}})
+
+# @traitfn f56{X,Y;  ST4{X,Y}}(x::X, y::Y) # note that ST4 is similar to {TT1{X},  TT2{Y}}
+# @traitfn f56{X,Y;  ST4{X,Y}}(x::X, y::Y) = 1
+# @traitfn f56{X,Y; !ST4{X,Y}}(x::X, y::Y) = 2
+
+# @test f56(A(),B())==1
+# @test f56(A(),A())==1
+# @test f56(B(),B())==2  # this does not work because Not{ST4}!={!TT1{X},  TT2{Y}}
+# @test f56(B(),A())==3
+# --> needs to be implemented with method II in traitdef.  Method III does not work!
 
 ######
 # Other tests


### PR DESCRIPTION
I think I'll merge this after a bit of settling. This adds:

- inheritance
- trait functions dispatching on several traits (although only a fixed set)

This is a breaking change because now trait-functions need to be initialized via: 
`@traitfn f{X; TR{X}}(x::X)`
 (sans `=...`).

I think this is as far as Holy Traits can be taken.  Going further would get into the Traits.jl territory of trait-dispatch and trait-definitions via method specifications.