### PR TITLE
Provide useful backtraces

### DIFF
--- a/test/backtraces.jl
+++ b/test/backtraces.jl
@@ -1,0 +1,30 @@
+###### BEGIN: LINE NUMBER SENSITIVITY ##########
+@traitdef BacktraceTr{X}
+
+@traitimpl BacktraceTr{Integer}
+
+@traitfn foo{X;  BacktraceTr{X}}(A::X) = backtrace()
+@traitfn foo{X; !BacktraceTr{X}}(A::X) = backtrace()
+###### END:   LINE NUMBER SENSITIVITY ##########
+# (the tests below depend on the particular line numbers in the code above)
+
+function hasline(bt, n)
+    for b in bt
+        lkup = StackTraces.lookup(b)
+        if length(lkup) >= 2
+            l1, l2 = lkup[1], lkup[2]
+            if (contains(string(l1.file), "backtraces.jl") &&
+                l1.func == :foo &&
+                l1.line == n &&
+                contains(string(l2.file), "SimpleTraits.jl"))
+                return true
+            end
+        end
+    end
+    false
+end
+
+@test hasline(foo(1), 6)
+@test hasline(foo(1.0), 7)
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,3 +101,7 @@ trait = SimpleTraits.trait
 # Other tests
 #####
 include("base-traits.jl")
+
+if VERSION >= v"0.5.0-dev"
+    include("backtraces.jl")
+end


### PR DESCRIPTION
By annotating the function body with the source location, we can get nice backtraces when our trait functions throw errors. Unfortunately, this does not yet seem to be enough to get accurate code coverage of trait functions (which is actually why I did this). But the useful error messages are nice.

Example:
```jl
using SimpleTraits

@traitdef IsInteger{X}

@traitimpl IsInteger{Integer}

@traitfn foo{X;  IsInteger{X}}(A::X) = error("oops 1")
@traitfn foo{X; !IsInteger{X}}(A::X) = error("oops 2")

julia> foo(1)
ERROR: oops 1
 in foo at /tmp/testbt.jl:7 [inlined]
 in foo at /home/tim/.julia/v0.5/SimpleTraits/src/SimpleTraits.jl:163 [inlined]
 in foo(::Int64) at /home/tim/.julia/v0.5/SimpleTraits/src/SimpleTraits.jl:169
```
Without this, you don't get that first all-important line.

This only works on julia 0.5, but it doesn't break julia 0.4.
