### PR TITLE
Turn on precompilation

### DIFF
--- a/src/SimpleTraits.jl
+++ b/src/SimpleTraits.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module SimpleTraits
 const curmod = module_name(current_module())
 


### PR DESCRIPTION
I'm getting a test failure that I suspect is due to the lack of a precompile statement (https://travis-ci.org/JuliaImages/ImageMetadata.jl/builds/162871367), so it would be awesome to tag a new release once this merges.
