### PR TITLE
Fix IndexStyle and abstract depwarns on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
 MacroTools 0.3.2
+Compat 0.19

--- a/src/SimpleTraits.jl
+++ b/src/SimpleTraits.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module SimpleTraits
 using MacroTools
+using Compat
 const curmod = module_name(current_module())
 
 # This is basically just adding a few convenience functions & macros
@@ -13,6 +14,8 @@ export Trait, istrait, @traitdef, @traitimpl, @traitfn, Not
 # but present to be compatible with Traits.jl.
 ## @doc """
 ## `abstract Trait{SUPER}`
+
+@compat abstract type Trait end #{SUPER}
 
 """
 All Traits are subtypes of abstract type Trait.
@@ -27,13 +30,15 @@ where X and Y are the types involved in the trait.
 (SUPER is not used here but in Traits.jl, thus retained for possible
 future compatibility.)
 """
-abstract Trait #{SUPER}
+Trait
+
+@compat abstract type Not{T<:Trait} <: Trait end
 
 """
 The set of all types not belonging to a trait is encoded by wrapping
 it with Not{}, e.g.  Not{Tr1{X,Y}}
 """
-abstract Not{T<:Trait} <: Trait
+Not
 
 # Helper to strip an even number of Not{}s off: Not{Not{T}}->T
 stripNot{T<:Trait}(::Type{T}) = T

--- a/src/base-traits.jl
+++ b/src/base-traits.jl
@@ -1,7 +1,9 @@
 module BaseTraits
 using SimpleTraits
 
-export IsLeafType, IsBits, IsImmutable, IsContiguous, IsFastLinearIndex,
+using Compat
+
+export IsLeafType, IsBits, IsImmutable, IsContiguous, IsIndexLinear,
        IsAnything, IsNothing, IsCallable
 
 "Trait which contains all types"
@@ -9,7 +11,7 @@ export IsLeafType, IsBits, IsImmutable, IsContiguous, IsFastLinearIndex,
 @traitimpl IsAnything{X} <- (x->true)(X)
 
 "Trait which contains no types"
-typealias IsNothing{X} Not{IsAnything{X}}
+@compat const IsNothing{X} = Not{IsAnything{X}}
 
 
 "Trait of all isbits-types"
@@ -33,17 +35,17 @@ typealias IsNothing{X} Not{IsAnything{X}}
 @traitimpl IsContiguous{X} <- Base.iscontiguous(X)
 
 "Array indexing trait."
-@traitdef IsFastLinearIndex{X} # https://github.com/JuliaLang/julia/pull/8432
-function islinearfast(X)
-    if Base.linearindexing(X)==Base.LinearFast()
+@traitdef IsIndexLinear{X} # https://github.com/JuliaLang/julia/pull/8432
+function isindexlinear(X)
+    if IndexStyle(X)==IndexLinear()
         return true
-    elseif  Base.linearindexing(X)==Base.LinearSlow()
+    elseif  IndexStyle(X)==IndexCartesian()
         return false
     else
         error("Not recognized")
     end
 end
-@traitimpl IsFastLinearIndex{X} <- islinearfast(X)
+@traitimpl IsIndexLinear{X} <- isindexlinear(X)
 
 # TODO
 ## @traitdef IsArray{X} # use for any array like type in the sense of container
@@ -51,5 +53,8 @@ end
 
 ## @traitdef IsMartix{X} # use for any LinearOperator
 ##                    # types<:AbstractArray are automatically part
+
+
+Base.@deprecate_binding IsFastLinearIndex IsIndexLinear
 
 end # module

--- a/test/base-traits.jl
+++ b/test/base-traits.jl
@@ -23,8 +23,8 @@ c = view(a, 1:2:5)
 @test istrait(IsContiguous{typeof(b)})
 @test !istrait(IsContiguous{typeof(c)})
 
-@test istrait(IsFastLinearIndex{Vector})
-@test !istrait(IsFastLinearIndex{AbstractArray})
+@test istrait(IsIndexLinear{Vector})
+@test !istrait(IsIndexLinear{AbstractArray})
 
 if VERSION < v"0.5.0-dev"
     # this give deprecation warning in Julia 0.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using SimpleTraits
+using Compat
 using Base.Test
 
 const trait = SimpleTraits.trait
@@ -43,7 +44,7 @@ const trait = SimpleTraits.trait
 @test trait(Tr2{Int, Float32})==Not{Tr2{Int, Float32}}
 
 # issue 9
-abstract A9
+@compat abstract type A9 end
 type B9<:A9 end
 type C9<:A9 end
 @traitdef Tr9{X}


### PR DESCRIPTION
When someone tags this, it should probably be a minor version bump since it introduces a new deprecation.