### PR TITLE
Use where syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - nightly
 # matrix:
 #   allow_failures:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# 2018-02-19
+
+Transitioned to where-function syntax.  Dropped Julia 0.6 support,
+with the last release supporting it v0.5.2.
+
 # 2017-11-23
 
 Dropped Julia 0.5 support, last release supporting it is v0.5.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-Compat 0.26.0
+julia 0.7
 MacroTools 0.3.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/base-traits.jl
+++ b/src/base-traits.jl
@@ -68,8 +68,8 @@ Base.@deprecate_binding IsFastLinearIndex IsIndexLinear
 
 "Trait of all iterator types"
 @traitdef IsIterator{X}
-@generated function SimpleTraits.trait{X}(::Type{IsIterator{X}})
-    method_exists(start, Tuple{X}) ? :(IsIterator{X}) : :(Not{IsIterator{X}})
+@generated function SimpleTraits.trait(::Type{IsIterator{X}}) where {X}
+    hasmethod(start, Tuple{X}) ? :(IsIterator{X}) : :(Not{IsIterator{X}})
 end
 
 end # module

--- a/test/backtraces.jl
+++ b/test/backtraces.jl
@@ -3,8 +3,8 @@
 
 @traitimpl BacktraceTr{Integer}
 
-@traitfn foo{X;  BacktraceTr{X}}(A::X) = backtrace()
-@traitfn foo{X; !BacktraceTr{X}}(A::X) = backtrace()
+@traitfn foo(A::X) where {X;  BacktraceTr{X}} = backtrace()
+@traitfn foo(A::X) where {X; !BacktraceTr{X}} = backtrace()
 ###### END:   LINE NUMBER SENSITIVITY ##########
 # (the tests below depend on the particular line numbers in the code above)
 

--- a/test/base-traits-inference.jl
+++ b/test/base-traits-inference.jl
@@ -5,7 +5,7 @@
 # Dict with base-traits to check using value[1] as type and value[2]
 # as number of lines allowed in llvm code
 cutoff = 5
-basetrs = [VERSION<v"0.7-" ? :IsLeafType=>:Int : :IsConcrete=>:Int,
+basetrs = [:IsConcrete=>:Int,
            :IsBits=>:Int,
            :IsImmutable=>:Int,
            :IsContiguous=>:(SubArray{Int64,1,Array{Int64,1},Tuple{Array{Int64,1}},false}),

--- a/test/base-traits.jl
+++ b/test/base-traits.jl
@@ -1,5 +1,4 @@
 using SimpleTraits.BaseTraits
-using Compat: view
 
 @test istrait(IsAnything{Any})
 @test istrait(IsAnything{Union{}})


### PR DESCRIPTION
Allows to use where syntax.  This is Julia 0.7 only as where syntax cannot work in 0.6, see https://github.com/JuliaLang/julia/issues/23211.

This fixes #46.

TODO:
- [x] update README
- [x] add NEWS item
- [ ] tag last Julia 0.6 release.