### PR TITLE
Allow specification of a docstring on functions which dispatch on traits (@traitfn)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleTraits"
 uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
-version = "0.9.0"
 author = ["Mauro Werder <mauro3@runbox.com>"]
+version = "0.9.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -13,6 +13,7 @@ julia = "≥ 1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Markdown"]

--- a/src/SimpleTraits.jl
+++ b/src/SimpleTraits.jl
@@ -320,16 +320,16 @@ let
         retsym = gensym()
         if hasmac
             fn = if oldfn_syntax
-                :(@dummy $fname{$(typs...)}($val, $(strip_kw(args1)...); $(kwargs...)) = ($pushloc; $retsym = $fbody; $poploc; $retsym))
+                :(Base.@__doc__ @dummy $fname{$(typs...)}($val, $(strip_kw(args1)...); $(kwargs...)) = ($pushloc; $retsym = $fbody; $poploc; $retsym))
             else
-                :(@dummy $fname($val, $(strip_kw(args1)...); $(kwargs...)) where {$(typs...)} = ($pushloc; $retsym = $fbody; $poploc; $retsym))
+                :(Base.@__doc__ @dummy $fname($val, $(strip_kw(args1)...); $(kwargs...)) where {$(typs...)} = ($pushloc; $retsym = $fbody; $poploc; $retsym))
             end
-            fn.args[1] = mac # replace @dummy
+            fn.args[findfirst(ex->isexpr(ex) && ex.head==:macrocall, fn.args)].args[1] = mac # replace @dummy
         else
             fn = if oldfn_syntax
-                :($fname{$(typs...)}($val, $(strip_kw(args1)...); $(kwargs...)) = ($pushloc; $retsym = $fbody; $poploc; $retsym))
+                :(Base.@__doc__ $fname{$(typs...)}($val, $(strip_kw(args1)...); $(kwargs...)) = ($pushloc; $retsym = $fbody; $poploc; $retsym))
             else
-                :($fname($val, $(strip_kw(args1)...); $(kwargs...)) where {$(typs...)} = ($pushloc; $retsym = $fbody; $poploc; $retsym))
+                :(Base.@__doc__ $fname($val, $(strip_kw(args1)...); $(kwargs...)) where {$(typs...)} = ($pushloc; $retsym = $fbody; $poploc; $retsym))
             end
         end
         # Create the trait dispatch function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using SimpleTraits
 using Test
+using Markdown
 
 const trait = SimpleTraits.trait
 
@@ -184,7 +185,6 @@ struct C9<:A9 end
 # above does not work with Traitor syntax
 @test_broken SimpleTraits.traitfn(:(defargs6a(x::::Tr1=1, y=2) = x+y))
 
-
 # traitfn with macro
 @traitfn @inbounds gg(x::X) where {X; Tr1{X}} = x
 @test gg(5)==5
@@ -230,6 +230,14 @@ struct C9<:A9 end
 @test f12t(1)==1
 @test f12t(5.5)==2
 
+# traitfn with docstring
+"Test documentation 1"
+@traitfn f13(x::X) where {X; Tr1{X}} = 1
+@test "Test documentation 1\n" == Markdown.plain(@doc f13)
+
+"Test documentation 2"
+@traitfn @generated f14(x::X) where {X; Tr1{X}} = 1
+@test "Test documentation 2\n" == Markdown.plain(@doc f14)
 
 ###
 # @traitimpl Tr{X} <- istr(X)


### PR DESCRIPTION
As the name already mentions adds the ability to document "@traitfn" functions like so
```
"some documentation"
@traitfn f(::X) where {X; IsNice{X}} = 1
```