### PR TITLE
Removed generated function for IsIterator

### DIFF
--- a/src/base-traits.jl
+++ b/src/base-traits.jl
@@ -61,15 +61,14 @@ Base.@deprecate_binding IsFastLinearIndex IsIndexLinear
 
 
 """
-Trait of all iterator types
+Trait of all iterator types.
 
-Note that this uses a generated function which queries `hasmethod`.  This is
-ill-defined behavior!  Although you might get away with it, see
-https://github.com/mauro3/SimpleTraits.jl/issues/40.
+NOTE: using this will lead to dynamic dispatch, see
+https://github.com/mauro3/SimpleTraits.jl/issues/40 for context.
 """
 @traitdef IsIterator{X}
-@generated function SimpleTraits.trait(::Type{IsIterator{X}}) where {X}
-    hasmethod(iterate, Tuple{X}) ? :(IsIterator{X}) : :(Not{IsIterator{X}})
+function SimpleTraits.trait(::Type{IsIterator{X}}) where {X}
+    hasmethod(iterate, Tuple{X}) ? IsIterator{X} : Not{IsIterator{X}}
 end
 
 end # module

--- a/test/base-traits-inference.jl
+++ b/test/base-traits-inference.jl
@@ -12,9 +12,13 @@ basetrs = [:IsConcrete=>:Int,
            :IsIndexLinear=>:(Vector{Int}),
            :IsAnything=>:Int,
            :IsNothing=>:Int,
-           :IsCallable=>:(typeof(sin)),
-           :IsIterator=>:(Dict{Int,Int})]
+           :IsCallable=>:(typeof(sin))]
+
 
 for (bt, tp) in basetrs
     @test @eval @check_fast_traitdispatch $bt $tp true
 end
+
+# IsIterator used dynamic dispatch as hasmethod is not inferable,
+# see https://github.com/mauro3/SimpleTraits.jl/issues/40.
+@test !(@eval @check_fast_traitdispatch IsIterator Dict{Int,Int} true)


### PR DESCRIPTION
This, finally, removes the evil generated function which used `hasmethod`.

x-ref: #40 

TODO: not sure whether this is breaking, or not.